### PR TITLE
Resolve autocomplete results not showing due to spaces in the query

### DIFF
--- a/intermine/webapp/src/main/java/org/intermine/web/autocompletion/AutoCompleter.java
+++ b/intermine/webapp/src/main/java/org/intermine/web/autocompletion/AutoCompleter.java
@@ -144,7 +144,7 @@ public class AutoCompleter
                 for (int i = 0; i < tmp.length; i++) {
                     query += tmp[i];
                     if (i < tmp.length - 1) {
-                        query += "* AND " + field+":";
+                        query += "* AND " + field + ":";
                     }
                 }
             }

--- a/intermine/webapp/src/main/java/org/intermine/web/autocompletion/AutoCompleter.java
+++ b/intermine/webapp/src/main/java/org/intermine/web/autocompletion/AutoCompleter.java
@@ -144,7 +144,7 @@ public class AutoCompleter
                 for (int i = 0; i < tmp.length; i++) {
                     query += tmp[i];
                     if (i < tmp.length - 1) {
-                        query += "* AND ";
+                        query += "* AND " + field+":";
                     }
                 }
             }


### PR DESCRIPTION
## Details

Modified old lucene implementation to adhere to the new solr. Had to add field name infront of splitted query. References https://github.com/intermine/intermine/issues/1849