### PR TITLE
create a new copyfield for facet fields

### DIFF
--- a/intermine/api/src/main/java/org/intermine/api/searchengine/solr/SolrKeywordSearchHandler.java
+++ b/intermine/api/src/main/java/org/intermine/api/searchengine/solr/SolrKeywordSearchHandler.java
@@ -64,7 +64,7 @@ public final class SolrKeywordSearchHandler implements KeywordSearchHandler
             newQuery.addField("id");
 
             for (KeywordSearchFacetData keywordSearchFacetData : facets){
-                newQuery.addFacetField(keywordSearchFacetData.getField());
+                newQuery.addFacetField("facet_" + keywordSearchFacetData.getField());
             }
 
             // add faceting selections
@@ -164,7 +164,7 @@ public final class SolrKeywordSearchHandler implements KeywordSearchHandler
             newQuery.setRows(0); //search results is not important here. Only facet categories
 
             for (KeywordSearchFacetData keywordSearchFacetData : facets){
-                newQuery.addFacetField(keywordSearchFacetData.getField());
+                newQuery.addFacetField("facet_" + keywordSearchFacetData.getField());
             }
 
             // add faceting selections
@@ -265,7 +265,7 @@ public final class SolrKeywordSearchHandler implements KeywordSearchHandler
 
             List<FacetField> facetFields = resp.getFacetFields();
 
-            FacetField facetField = resp.getFacetField(facet.getField());
+            FacetField facetField = resp.getFacetField("facet_" + facet.getField());
 
             List<FacetField.Count> counts = facetField.getValues();
 


### PR DESCRIPTION
## Details

References https://github.com/intermine/intermine/issues/1862 https://github.com/intermine/intermine/issues/1852
https://github.com/intermine/intermine/issues/1863

I created a copy field for all facet fields with the fieldtype "string". String fieldtypes are not tokenized. CopyFields are a replication of normal fields. So when I give a facet query, I give the fieldname of the copy Field and not the original field. Hence results will not have split on whitespaces.

Also I have created a Lowcase Filter so that queries will not be case sensitive.
